### PR TITLE
Remove the Path::Tiny dependency

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -34,7 +34,6 @@ include_dotfiles = 1
 
 [Prereqs]
 perl = 5.010
-Path::Tiny = 0.011
 
 [Prereqs / BuildRequires]
 Test::CPAN::Meta =

--- a/lib/Dotenv.pm
+++ b/lib/Dotenv.pm
@@ -4,7 +4,6 @@ use strict;
 use warnings;
 
 use Carp       ();
-use Path::Tiny ();
 
 sub import {
     my ( $package, @args ) = @_;
@@ -65,6 +64,18 @@ my $parse = sub {
     return %kv;
 };
 
+my $file_slurp = sub {
+    my ($filename) = @_;
+    open my $fh, '<:utf8', $filename
+        or die "Dotenv: Could not open $filename: $!";
+    my $out = do {
+        local $/;
+        <$fh>
+    };
+    close $fh or die "Dotenv: Could not close $filename: $!";
+    return $out;
+};
+
 sub parse {
     my ( $package, @sources ) = @_;
     @sources = ('.env') if !@sources;
@@ -77,7 +88,7 @@ sub parse {
         my %kv;
         my $ref = ref $source;
         if ( $ref eq '' ) {
-            %kv = $parse->( Path::Tiny->new($source)->slurp_utf8, \%env );
+            %kv = $parse->( $file_slurp->($source), \%env );
         }
         elsif ( $ref eq 'HASH' ) {    # bare hash ref
             %kv = %$source;

--- a/t/parse.t
+++ b/t/parse.t
@@ -1,13 +1,12 @@
 use strict;
 use warnings;
 use Test::More;
-use Path::Tiny;
 use Dotenv;
 
 for my $env ( glob 't/env/*.env' ) {
     ( my $pl = $env ) =~ s/\.env$/\.pl/;
     next unless -e $pl;
-    my %expected = eval Path::Tiny->new($pl)->slurp_utf8;
+    my %expected = do "./$pl";
 
     # parse
     my $got = Dotenv->parse($env);

--- a/t/sources.t
+++ b/t/sources.t
@@ -1,7 +1,6 @@
 use strict;
 use warnings;
 use Test::More;
-use Path::Tiny;
 use IO::File;
 use Dotenv;
 
@@ -11,6 +10,8 @@ my %expected = (
     Barbalib    => 'orange',
 );
 
+open my $fh, '<:utf8', 't/env/barb.env';
+
 my @sources = (
     \ << 'EOT',
 Barbabright = blue
@@ -19,7 +20,7 @@ export Barbapapa = pink
 EOT
     [ 'Barbabright=blue', "Barbalib = orange\n   Barbapapa = pink    " ],
     \%expected,
-    Path::Tiny->new('t/env/barb.env')->openr_utf8,
+    $fh,
     do {
         my $io = IO::File->new( 't/env/barb.env', 'r' );
         $io->binmode(':utf8');


### PR DESCRIPTION
Installing Dotenv brings in *dozens* of dependencies, some of them
requiring XS.

This patch makes it just use open(), and removes the dep.