### PR TITLE
Test::Pod & friends are certainly *NOT* required for build

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -36,6 +36,8 @@ include_dotfiles = 1
 perl = 5.010
 
 [Prereqs / BuildRequires]
+
+[Prereqs / DevelopRequires]
 Test::CPAN::Meta =
 Test::Pod =
 Test::Pod::Coverage =


### PR DESCRIPTION
As is, `META.yml` looks like:

```
build_requires:
  ExtUtils::MakeMaker: '0'
  File::Spec: '0'
  IO::File: '0'
  IO::Handle: '0'
  IPC::Open3: '0'
  Test::CPAN::Meta: '0'
  Test::More: '0'
  Test::Pod: '0'
  Test::Pod::Coverage: '0'
  perl: '5.010'
```

Which forces the `Test::*` modules to be installed for everyone. However,
these are only necessary for the development of the module itself.